### PR TITLE
Updated publish and subscribe pub/sub method added

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function getTopic(pubsub, name, callback) {
  * @param {Function} callback Callback function (err, subscription)
  */
 function getSubscription(name, config, topic, callback) {
-    topic.subscribe(name, config, callback);
+    topic.createSubscription(name, config, callback);
 }
 
 /**
@@ -160,7 +160,10 @@ function adapter(pubsub, opts) {
      */
 
     PubsubAdapter.prototype.publish = function (topic, channel, message) {
-        this.topics[topic].publish(Object.assign({}, message, { channel }), err => {
+        // new pub sub publish method
+        let dataBuffer = Buffer.from(JSON.stringify(Object.assign({}, message, { channel })));
+        
+        this.topics[topic].publisher().publish(dataBuffer, err => {
             if (err) {
                 this.emit('error', err);
             }
@@ -178,7 +181,7 @@ function adapter(pubsub, opts) {
             return debug('subscription %s is closed', subscription.name);
         }
 
-        const channel = msg.data.channel;
+        const channel = JSON.parse(Buffer.from(msg.data, 'base64').toString('utf8')).channel;
 
         if (!channelMatches(channel, this.channel)) {
             return debug('ignore different channel');

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ function adapter(pubsub, opts) {
     PubsubAdapter.prototype.publish = function (topic, channel, message) {
         // new pub sub publish method
         let dataBuffer = Buffer.from(JSON.stringify(Object.assign({}, message, { channel })));
-        
+
         this.topics[topic].publisher().publish(dataBuffer, err => {
             if (err) {
                 this.emit('error', err);
@@ -181,7 +181,9 @@ function adapter(pubsub, opts) {
             return debug('subscription %s is closed', subscription.name);
         }
 
-        const channel = JSON.parse(Buffer.from(msg.data, 'base64').toString('utf8')).channel;
+        const data = JSON.parse(Buffer.from(msg.data, 'base64').toString('utf8'));
+
+        const channel = data.channel;
 
         if (!channelMatches(channel, this.channel)) {
             return debug('ignore different channel');

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ module.exports = adapter;
 function getTopic(pubsub, name, callback) {
     pubsub.createTopic(name, (err, topic) => {
         // topic already exists.
-        if (err && err.code === 409) {
+        if (err && err.code === 6) {
             return callback(null, pubsub.topic(name));
         }
         return callback(err, topic);

--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
   },
   "homepage": "https://github.com/elegantmonkeys/socket.io-pubsub#readme",
   "dependencies": {
-    "async": "^2.4.0",
-    "debug": "^2.2.0",
-    "shortid": "^2.2.6",
-    "socket.io-adapter": "^1.1.0"
+    "async": "^2.6.1",
+    "debug": "^3.1.0",
+    "shortid": "^2.2.8",
+    "socket.io-adapter": "^1.1.1"
   },
   "devDependencies": {
-    "@google-cloud/pubsub": "^0.11.0",
-    "code": "^3.0.1",
-    "lab": "^10.7.1",
-    "socket.io": "^2.0.1",
-    "socket.io-client": "^2.0.1",
-    "tape": "^4.5.1"
+    "@google-cloud/pubsub": "^0.19.0",
+    "code": "^5.2.0",
+    "lab": "^15.5.0",
+    "socket.io": "^2.1.1",
+    "socket.io-client": "^2.1.1",
+    "tape": "^4.9.1"
   }
 }


### PR DESCRIPTION
- updated most of the functions based on new @google-cloud/pubsub library.
1. topic.subscribe to topic.createSubscription
2. topics[topic].publish to topics[topic].publisher().publish
3. now need to pass data as string buffer or array.