### PR TITLE
Fixed duplicate data declaration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -189,8 +189,6 @@ function adapter(pubsub, opts) {
             return debug('ignore different channel');
         }
 
-        const data = msg.data;
-
         if (this.uid === data.senderId) return debug('ignore same uid');
 
         const packet = data.packet;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@google-cloud/pubsub": "^0.19.0",
     "code": "^5.2.0",
-    "lab": "^15.5.0",
+    "lab": "^17.3.0",
     "socket.io": "^2.1.1",
     "socket.io-client": "^2.1.1",
     "tape": "^4.9.1"

--- a/test/index.js
+++ b/test/index.js
@@ -93,7 +93,6 @@ describe('socket.io-pubsub', () => {
                                 client1.disconnect();
                                 client2.disconnect();
                                 client3.disconnect();
-                                done();
                             }, 2000);
                         });
                     });
@@ -118,7 +117,6 @@ describe('socket.io-pubsub', () => {
                     expect(c.adapter.sids[c.id] || {}).to.be.empty();
                     expect(c.adapter.rooms || []).to.be.empty();
                     client.disconnect();
-                    done();
                 });
                 c.disconnect();
             });


### PR DESCRIPTION
Fixed the duplicate data declaration which introduces a runtime error.

Additionally updated lab to v17 and removed the no longer supported done() calls in tests (see [Stackoverflow explanation](https://stackoverflow.com/questions/49547962/testing-using-hapijs-lab-done-is-not-a-function)