### PR TITLE
Change request: allow subscription attributes to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ process, you should use [socket.io-emitter](https://github.com/socketio/socket.i
 
 ### adapter(pubsub[, opts])
 
-`pubsub` is a [google-cloud](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud) [pubsub](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/pubsub) object. 
+`pubsub` is a [google-cloud](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud) [pubsub](https://googlecloudplatform.github.io/google-cloud-node/#/docs/google-cloud/pubsub) object.
 
 The following options are allowed:
 
 - `key`: the topic name of the pub/sub events (`socket.io`)
+- `createSubscriptionOpts`: [options for creating a subscription](https://googleapis.dev/nodejs/pubsub/latest/global.html#CreateSubscriptionRequest)
 
 
 ### PubsubAdapter

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,7 @@ function adapter(pubsub, opts) {
 
     const prefix = opts.key || 'socket.io';
     const uid = `socket.io-${shortid.generate()}`;
+    const createSubscriptionOpts = opts.createSubscriptionOpts || {};
 
     /**
      * PubsubAdapter constructor.
@@ -84,6 +85,7 @@ function adapter(pubsub, opts) {
         this.prefix = prefix;
         this.channel = prefix + '#' + nsp.name + '#';
         this.topics = {};
+        this.createSubscriptionOpts = createSubscriptionOpts;
         this.subscriptions = {};
 
         this.subscribe(this.prefix, () => {
@@ -128,7 +130,7 @@ function adapter(pubsub, opts) {
                 callback(null, topicObj);
             },
 
-            getSubscription.bind(null, this.uid, {})
+            getSubscription.bind(null, this.uid, this.createSubscriptionOpts)
         ], (err, subscription) => {
 
             if (err) {


### PR DESCRIPTION
Hi there!  For your consideration: I'd like to propose a change to extend the options for the PubSub adapter so that subscription creation options can be specified.

This would allow subscriptions to be configured with, among the other possible configuration options, a TTL.  The TTL option is very useful in cases where nodes using this adapter auto-scale.  Setting TTL would allow subscriptions to expire sooner (rather than later) to conserve resources.

Just a thought.  Let me know what you think.  Any feedback is appreciated, and I can certainly adopt suggestions in this PR.