### PR TITLE
Handle error code '5' as 'NOT_FOUND'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -142,7 +142,7 @@ function adapter(pubsub, opts) {
                 this.initializing = false;
                 subscription.on('message', this.onmessage.bind(this, subscription));
                 subscription.on('error', err => {
-                    if (err.code !== 404) {
+                    if (![404, 5].includes(err.code)) {
                         throw err;
                     }
                 });


### PR DESCRIPTION
When testing against the pubsub emulator, I am seeing:

```
Error: Failed to "modifyAckDeadline" for 1 message(s). Reason: 5 NOT_FOUND: Subscription does not exist
    at /home/simon/code/radio/backend/node_modules/@google-cloud/pubsub/src/message-queues.ts:240:15
    at runNextTicks (internal/process/task_queues.js:62:5)
    at processImmediate (internal/timers.js:429:9)
```

This happens intermittently, on socket disconnect. From what I can see of the error, it looks like this message is related to the socket that has gone away, in which case `NOT_FOUND` seems like a sensible response.

The code `404` is listed for `NOT_FOUND` in https://cloud.google.com/pubsub/docs/reference/error-codes

However, this code for `NOT_FOUND` in `grpc` is listed as `5`: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md - This is the error that I am getting back in this case.

This could be a bug in the emulator, but handling this error code here also works and is the simpler fix. Given that this error does not overlap with any of the HTTP error codes listed in the pubsub reference, I think this is fine.

Making this change locally in my app has got rid of the error above, without any discernable negative side-effects.